### PR TITLE
Support big endian architectures.

### DIFF
--- a/src/crypting.c
+++ b/src/crypting.c
@@ -54,7 +54,12 @@ static const UInt4 rinit[] = {
     0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
     0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19 };
 
-/* TODO: These depend on endianness */
+#ifdef WORDS_BIGENDIAN
+#include <string.h>
+#define be32decode(dst, src, len) memcpy(dst, src, len)
+#define be32encode(dst, src, len) memcpy(dst, src, len)
+#define store64be(dst, x) *dst = x
+#else
 static void be32decode(UInt4 *dst, const UInt1 *src, UInt len)
 {
     UInt i;
@@ -88,6 +93,7 @@ static void store64be(UInt8 *dst, UInt8 x)
             ((x << 40) & ((UInt8)0xff << 48)) |
             ((x << 56))));
 }
+#endif
 
 typedef struct sha256_state_t {
     UInt4 r[8];      /* Current hash value register */


### PR DESCRIPTION
This pull request uses a shell trick to distinguish between little and big endian architectures.  The trick is well known, as a web search will show.  The code is structured in such a way that if systems without a shell compile it, they will get the little endian version by default (because BIGENDIAN is undefined).

Note: I initially named the macro BIG_ENDIAN, but then discovered that gcc defines that name on all architectures; it has the value 1234 on big endian architectures and 4321 on little endian architectures.

The approach taken by this pull request is compiler and C library agnostic.  There is a much shorter solution if glibc is available (using endian.h).

I did a test build on Fedora's build system: https://koji.fedoraproject.org/koji/taskinfo?taskID=38043230.  The build succeeded and all tests passed on all supported architectures, including s390x, which is a big endian architecture.