### PR TITLE
Use SET_TYPE_OBJ instead of SetTypeDatObj

### DIFF
--- a/src/crypting.c
+++ b/src/crypting.c
@@ -210,7 +210,7 @@ Obj FuncCRYPTING_SHA256_INIT(Obj self)
     sha256_state_t *sptr;
 
     result = NewBag(T_DATOBJ, sizeof(UInt4) + sizeof(sha256_state_t));
-    SetTypeDatObj(result, CRYPTING_SHA256_State_Type);
+    SET_TYPE_OBJ(result, CRYPTING_SHA256_State_Type);
 
     sptr = (sha256_state_t *)(&ADDR_OBJ(result)[1]);
     sha256_init(sptr);


### PR DESCRIPTION
This amounts to the same, as SET_TYPE_OBJ ends up calling SetTypeDatObj for a
T_DATOBJ. But SetTypeDatObj is only exposed in a header for silly internal
reasons in GAP, and I hope we can undo that eventually. The main blocker is
this package using it.