### PR TITLE
Replace compiled.h by gap_all.h

### DIFF
--- a/src/crypting.c
+++ b/src/crypting.c
@@ -2,7 +2,7 @@
  * crypting: Hashes and Crypto in GAP
  */
 
-#include "compiled.h"   // GAP headers
+#include "gap_all.h"   // GAP headers
 
 static Obj CRYPTING_SHA256_State_Type;
 


### PR DESCRIPTION
No functional change for this package but makes it future-proof.
